### PR TITLE
fix/move kms key ring to variable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,7 +66,7 @@ resource "google_project_iam_member" "app-role-binding" {
 
 // HSM-KMS setup for signers
 resource "google_kms_key_ring" "gasolina_key_ring" {
-  name       = "gasolinaKeyRing"
+  name       = var.kms_key_ring
   location   = "global"
 
   depends_on = [module.enabled_google_apis.project_id]
@@ -179,7 +179,7 @@ resource "google_cloud_run_service" "gasolina_api" {
         }
         env {
           name  = "GCP_KEY_RING_ID"
-          value = "gasolinaKeyRing"
+          value = var.kms_key_ring
         }
         env {
           name  = "LAYERZERO_SUPPORTED_ULN_VERSIONS"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,3 +56,9 @@ variable "available_chain_names" {
   type = string
   description = "Comma separated list of chain names that gasolina will support e.g. ethereum,bsc,avalanche,polygon"
 }
+
+
+variable "kms_key_ring" {
+  type = string
+  description = "The name of the key ring to create in KMS"
+}


### PR DESCRIPTION
Because Google can't destroy the KMS key string after running terraform destroy, then we reapply we will receive conflicted key string.  We had to import this key string or change the name in main.tf right now it's hardcore.