### PR TITLE
fix: patch elliptic, protobufjs, valibot, ws, node-forge CVEs via yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "elliptic": "^6.6.1",
         "protobufjs": "^7.2.5",
         "bip32": "5.0.1",
-        "ws": "^7.5.10"
+        "ws": "^7.5.10",
+        "node-forge": "^1.4.0"
     },
     "dependencies": {
         "@layerzerolabs/lz-definitions": "^3.0.123",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "resolutions": {
         "jws": "4.0.1",
         "elliptic": "^6.6.1",
-        "protobufjs": "^7.2.5"
+        "protobufjs": "^7.2.5",
+        "bip32": "5.0.1",
+        "ws": "^7.5.10"
     },
     "dependencies": {
         "@layerzerolabs/lz-definitions": "^3.0.123",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
         "watch": "tsc -w"
     },
     "resolutions": {
-        "jws": "4.0.1"
+        "jws": "4.0.1",
+        "elliptic": "^6.6.1",
+        "protobufjs": "^7.2.5"
     },
     "dependencies": {
         "@layerzerolabs/lz-definitions": "^3.0.123",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,10 +4056,10 @@ node-fetch@^2.6.1, node-fetch@^2.6.9, node-fetch@^2.7.0:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1.3.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.3.tgz#0ad80f6333b3a0045e827ac20b7f735f93716751"
-  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
+node-forge@^1.3.1, node-forge@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,15 +2269,15 @@ bindings@^1.3.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip32@^5.0.0-rc.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bip32/-/bip32-5.0.0.tgz#2d1d9069426dfb74a1ba4735aa153dfa398fa1b8"
-  integrity sha512-h043yQ9n3iU4WZ8KLRpEECMl3j1yx2DQ1kcPlzWg8VZC0PtukbDiyLDKbe6Jm79mL6Tfg+WFuZMYxnzVyr/Hyw==
+bip32@5.0.1, bip32@^5.0.0-rc.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-5.0.1.tgz#08ccd31bbc57e62197ea74e039795a590302f332"
+  integrity sha512-PWlHIAgYCfVhwqNpZyeakHXuLAGyN6rEQZnhxHxKI3BoFJRVWLl26455fhRlHsmbYcV986HqtPnt33Edu5sTCw==
   dependencies:
     "@noble/hashes" "^1.2.0"
     "@scure/base" "^1.1.1"
     uint8array-tools "^0.0.8"
-    valibot "^0.37.0"
+    valibot "^1.2.0"
     wif "^5.0.0"
 
 bip39@^3.1.0:
@@ -4948,11 +4948,6 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-valibot@^0.37.0:
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/valibot/-/valibot-0.37.0.tgz#b71f597a581c716f6546a3b53cefd2829b559c55"
-  integrity sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==
-
 valibot@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/valibot/-/valibot-1.2.0.tgz#8fc720d9e4082ba16e30a914064a39619b2f1d6f"
@@ -5023,30 +5018,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@7.4.6:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
-
-ws@8.17.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
-
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
-
-ws@^7.5.10:
+ws@7.4.6, ws@8.17.1, ws@8.18.0, ws@^7.5.10, ws@^8.18.0, ws@^8.5.0:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
-
-ws@^8.18.0, ws@^8.5.0:
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
-  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
 
 xmlcreate@^2.0.4:
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2765,20 +2765,7 @@ ed25519-hd-key@^1.3.0:
     create-hmac "1.1.7"
     tweetnacl "1.0.3"
 
-elliptic@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
-
-elliptic@6.6.1, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.7:
+elliptic@6.5.4, elliptic@6.6.1, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.7, elliptic@^6.6.1:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
@@ -3790,7 +3777,7 @@ jwa@^2.0.1:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^4.0.0, jws@^4.0.1:
+jws@4.0.1, jws@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
   integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
@@ -4283,25 +4270,7 @@ protobufjs-cli@1.1.1:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
-  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protobufjs@^7.0.0, protobufjs@^7.2.5, protobufjs@^7.3.2:
+protobufjs@7.2.4, protobufjs@^7.0.0, protobufjs@^7.2.5, protobufjs@^7.3.2:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
   integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==


### PR DESCRIPTION
## Description

Patches vulnerable transitive dependencies identified in the April 13, 2026 security scan:

- **elliptic** (GHSA-vjh7-7g9h-fjfh): yarn resolution to `^6.6.1`
- **protobufjs** (CVE-2023-36665): yarn resolution to `^7.2.5`
- **valibot** (CVE-2025-66020): `bip32` resolution to `5.0.1`, which bumps its internal valibot dep from `0.37.0` to `^1.2.0`. Chain: `lz-solana-sdk-v2 → lz-utilities → @initia/initia.js → bip32`
- **ws** (CVE-2024-37890): yarn resolution to `^7.5.10`
- **node-forge** (CVE-2026-33891, CVE-2026-33894, CVE-2026-33895, CVE-2026-33896): yarn resolution to `^1.4.0`

Note: `bigint-buffer` (CVE-2025-3194) has no available fix upstream and is deferred.

## Type of Change

- [x] 🧹 Chore (dependency updates, build changes, tooling, etc.)

## Plan

N/A — yarn resolutions to force patched versions of vulnerable transitive dependencies.

## Impact/Screenshots

No functional changes. Dependency resolutions only.

## Checklist

- [x] I have ensured that this PR is not too large. I understand that large PRs will be declined. I have created small/chunked and a scoped PR.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas and added/improved docs.

## Additional Notes

- `bigint-buffer` CVE-2025-3194 has no fix available — no patched version exists upstream. To be addressed when a fix is released.
- `bip32` resolution can be removed once `@layerzerolabs/lz-utilities` ships a version with an updated `@initia/initia.js` dependency upstream.