### PR TITLE
fix: bump aws-cdk-lib and lz-solana-sdk-v2 to resolve minimatch CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     },
     "dependencies": {
         "@layerzerolabs/lz-definitions": "^3.0.123",
-        "@layerzerolabs/lz-solana-sdk-v2": "3.0.123",
+        "@layerzerolabs/lz-solana-sdk-v2": "3.0.167",
         "args": "^5.0.3",
-        "aws-cdk-lib": "^2.62.1",
+        "aws-cdk-lib": "^2.249.0",
         "axios": "^1.3.1",
         "bs58": "^5.0.0",
         "command-line-args": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,23 +25,31 @@
   resolved "https://registry.yarnpkg.com/@aptos-labs/aptos-client/-/aptos-client-2.1.0.tgz#c0265a655f7b41cd5f858f9f261289a6a8b28327"
   integrity sha512-ttdY0qclRvbYAAwzijkFeipuqTfLFJnoXlNIm58tIw3DKhIlfYdR6iLqTeCpI23oOPghnO99FZecej/0MTrtuA==
 
-"@aws-cdk/asset-awscli-v1@2.2.258":
-  version "2.2.258"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.258.tgz#638854db7ffe218076091360feb9dcc69e8bedba"
-  integrity sha512-TL3I9cIue0bAsuwrmjgjAQaEH6JL09y49FVQMDhrz4jJ2iPKuHtdrYd7ydm02t1YZdPZE2M0VNj6VD4fGIFpvw==
+"@aws-cdk/asset-awscli-v1@2.2.273":
+  version "2.2.273"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz#81efd05df3f44c5e604f1d43c4b48e12874b0bd3"
+  integrity sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==
 
-"@aws-cdk/asset-node-proxy-agent-v6@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
-  integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
+"@aws-cdk/asset-node-proxy-agent-v6@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz#184f980024d67ad60bdc52ab88c59c73fa070346"
+  integrity sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==
 
-"@aws-cdk/cloud-assembly-schema@^48.20.0":
-  version "48.20.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz#a2b60373cfbe228f901f62f0d7e2c5e2fe40702d"
-  integrity sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==
+"@aws-cdk/cloud-assembly-api@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.1.tgz#43884b6637c002731115ff922bd256dd8b231ef5"
+  integrity sha512-24ARpDQzF39UTickUgDH6RIs5otPG4aaKJZ93XUSNwiPSR9T+h7gXSF982+NZVYK+7SetQaqrVbm4lcF6dmXWw==
   dependencies:
     jsonschema "~1.4.1"
-    semver "^7.7.2"
+    semver "^7.7.4"
+
+"@aws-cdk/cloud-assembly-schema@^53.0.0":
+  version "53.14.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.14.0.tgz#aed5fed83657ed904937296616ae2a5f2c109f21"
+  integrity sha512-prx2sbFfKrVf3NNXMOmWq6lsIBeWQDIqMTILLAddGiidn9j7OnLUubknWpJlLozMveTvQELdI++nUwq6jwCm9g==
+  dependencies:
+    jsonschema "~1.4.1"
+    semver "^7.7.4"
 
 "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.28.6":
   version "7.28.6"
@@ -1069,18 +1077,18 @@
   dependencies:
     lodash "^4.17.21"
 
-"@layerzerolabs/lz-core@^3.0.152":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-core/-/lz-core-3.0.152.tgz#0b2537322cc9032d6f73c28e9f4bad11047fc7e4"
-  integrity sha512-Myz/jXrvKSf+0NdydFBMYN8zCD272vCf+5O115wa5lnerMB57dWKT7/0CqPhgedrowsvzFPpgcF6/jZtb841pw==
+"@layerzerolabs/lz-core@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-core/-/lz-core-3.0.167.tgz#84aba843a36000bc49bb3707f18dbe8c1107f87e"
+  integrity sha512-AogFBGacIdCn3oDxfz5HOiL3QjDoJv+/b+DuXcGsrrewGm7zvUGAHGZQADP0eRAE5Tle3gDrScKY0ZLfa1D8rg==
 
-"@layerzerolabs/lz-corekit-solana@^3.0.123":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-corekit-solana/-/lz-corekit-solana-3.0.152.tgz#fd7626ae7515d85311de474ffd15e1bccd51282c"
-  integrity sha512-CbfVnin3/FGpnotsHy91t4uGVNWVmrLxt2ixtF7joX9JS2SBDocilnFtK5ZeaTneUYp5hbUPvs/kJKUDGvoz9A==
+"@layerzerolabs/lz-corekit-solana@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-corekit-solana/-/lz-corekit-solana-3.0.167.tgz#6db98ad4239329a88a4863c895b0ce947aaf205f"
+  integrity sha512-vYyMDWIA9jVgzI5uWHOGzegz9/lZmnd/MdG4zhhsN3ZljMGqz2R6SbbZgdmQLBgHfC4PK+6fIc5hG9b8WbQWjg==
   dependencies:
-    "@layerzerolabs/lz-core" "^3.0.152"
-    "@layerzerolabs/lz-utilities" "^3.0.152"
+    "@layerzerolabs/lz-core" "^3.0.167"
+    "@layerzerolabs/lz-utilities" "^3.0.167"
     "@metaplex-foundation/umi" "^0.9.2"
     "@metaplex-foundation/umi-eddsa-web3js" "^0.9.2"
     "@metaplex-foundation/umi-program-repository" "^0.9.2"
@@ -1093,20 +1101,27 @@
     ed25519-hd-key "^1.3.0"
     memoizee "^0.4.17"
 
-"@layerzerolabs/lz-definitions@^3.0.123", "@layerzerolabs/lz-definitions@^3.0.152":
+"@layerzerolabs/lz-definitions@^3.0.123":
   version "3.0.152"
   resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-definitions/-/lz-definitions-3.0.152.tgz#cf8c394f1dad537a0cd0087e5a8d4ca2722fb1d9"
   integrity sha512-igblZrQhQdMPaaC4sc090qWMCE0h+uzzhr9P6udx45S+CGV1cOfRy2xjYzHNoKlMUvBTd+pGP1swTmpzk6Hp0w==
   dependencies:
     tiny-invariant "^1.3.1"
 
-"@layerzerolabs/lz-foundation@^3.0.123":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-foundation/-/lz-foundation-3.0.152.tgz#4739173ff9dc39b36999f3cd5550e5435bac2ffe"
-  integrity sha512-eYFC3aDWN3c7cS2zepDJvv+4Pss4ssjlM4wL+EGTrWXemv8gYNOibOCxH9JmWGN4cO0Qm1ngRPD8Dm1Ua55mzQ==
+"@layerzerolabs/lz-definitions@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-definitions/-/lz-definitions-3.0.167.tgz#b5c0dd4c4b1bf686712bab5ea80d789da7367611"
+  integrity sha512-cKDOGHE0tFai1wfGAJ/xbaNVDRZMkAiIjGBa/RkyMxwpKi6n796F3fjrwyLeA4IKrxF1Uoc8O+rhQkt/O7vwYg==
   dependencies:
-    "@layerzerolabs/lz-definitions" "^3.0.152"
-    "@layerzerolabs/lz-utilities" "^3.0.152"
+    tiny-invariant "^1.3.1"
+
+"@layerzerolabs/lz-foundation@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-foundation/-/lz-foundation-3.0.167.tgz#e870ba700eaba57342e272f21456888145b1707f"
+  integrity sha512-3G/6k7gbN5HDGcIr4EzbYBB8MSJibqWN5WxMVkl+TG8xaPymdQXU9gnpDa48hp0/vDejat9dZmHjhCgBJj593A==
+  dependencies:
+    "@layerzerolabs/lz-definitions" "^3.0.167"
+    "@layerzerolabs/lz-utilities" "^3.0.167"
     "@noble/ed25519" "^1.7.1"
     "@noble/hashes" "^1.3.2"
     "@noble/secp256k1" "^1.7.1"
@@ -1114,15 +1129,15 @@
     bech32 "^2.0.0"
     memoizee "^0.4.17"
 
-"@layerzerolabs/lz-serdes@^3.0.123":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-serdes/-/lz-serdes-3.0.152.tgz#9edb54af417cc382892489d90d3780098c137800"
-  integrity sha512-TTHbdVmVaVEdhUgUwTGn+38pd+6VZAJ23SlYjWYzNED7RJKFCglNfZ8+delb6opuQ5Qi+CPwlXyqoER0jny6cw==
+"@layerzerolabs/lz-serdes@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-serdes/-/lz-serdes-3.0.167.tgz#2d151c4e10f37e7fe4ca62e96dbb3fc7cda4abcd"
+  integrity sha512-R+z9LYO/ifSMJaIQX+o7qV1NC7XXBfoxsJcQpTYBFE5toX8ZnyUjSn2lKzjxFLAemEhVg7sYS8EooxckGs9XwA==
   dependencies:
     "@coral-xyz/anchor" "^0.29.0"
-    "@layerzerolabs/lz-core" "^3.0.152"
-    "@layerzerolabs/lz-utilities" "^3.0.152"
-    "@layerzerolabs/tron-utilities" "^3.0.152"
+    "@layerzerolabs/lz-core" "^3.0.167"
+    "@layerzerolabs/lz-utilities" "^3.0.167"
+    "@layerzerolabs/tron-utilities" "^3.0.167"
     aptos "^1.20.0"
     bip39 "^3.1.0"
     ed25519-hd-key "^1.3.0"
@@ -1130,17 +1145,17 @@
     memoizee "^0.4.17"
     tronweb "^5.3.1"
 
-"@layerzerolabs/lz-solana-sdk-v2@3.0.123":
-  version "3.0.123"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-solana-sdk-v2/-/lz-solana-sdk-v2-3.0.123.tgz#78c9e18808762f7e342a8b93e1db59688d92957f"
-  integrity sha512-LsQ2nkkDwCcuRyQDiiPQORW9teQS5Z+2FuTWLkDdbapmT0bZXYR1IabYF8a77IVlAQ7EP47dXjRH/Gd1u5q8iA==
+"@layerzerolabs/lz-solana-sdk-v2@3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-solana-sdk-v2/-/lz-solana-sdk-v2-3.0.167.tgz#92029937d152e8e717f65547495c2597625f0524"
+  integrity sha512-hrLxFV+Mo+GGRfMaKUyKL+hxxL34nZ2ekDjuZbVso/d7omilaHhb6oOryvqzgX5/1tj57pfpoeezeTbdjiTIZA==
   dependencies:
-    "@layerzerolabs/lz-corekit-solana" "^3.0.123"
-    "@layerzerolabs/lz-definitions" "^3.0.123"
-    "@layerzerolabs/lz-foundation" "^3.0.123"
-    "@layerzerolabs/lz-serdes" "^3.0.123"
-    "@layerzerolabs/lz-utilities" "^3.0.123"
-    "@layerzerolabs/lz-v2-utilities" "^3.0.123"
+    "@layerzerolabs/lz-corekit-solana" "^3.0.167"
+    "@layerzerolabs/lz-definitions" "^3.0.167"
+    "@layerzerolabs/lz-foundation" "^3.0.167"
+    "@layerzerolabs/lz-serdes" "^3.0.167"
+    "@layerzerolabs/lz-utilities" "^3.0.167"
+    "@layerzerolabs/lz-v2-utilities" "^3.0.167"
     "@metaplex-foundation/beet" "^0.7.1"
     "@metaplex-foundation/beet-solana" "^0.4.0"
     "@metaplex-foundation/mpl-toolbox" "^0.9.2"
@@ -1155,15 +1170,15 @@
     bs58 "^5.0.0"
     tiny-invariant "^1.3.1"
 
-"@layerzerolabs/lz-utilities@^3.0.123", "@layerzerolabs/lz-utilities@^3.0.152":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-utilities/-/lz-utilities-3.0.152.tgz#ec6a02d412deaddff9d792506c1095f2094156eb"
-  integrity sha512-yb+CdSYuG4QD0spFwxyeAkLfjQvdDrltl0BCrTJXE0ifBP4te9KQGISZNAO3/+mMBliC2NqHxCXDiLGjIdygNw==
+"@layerzerolabs/lz-utilities@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-utilities/-/lz-utilities-3.0.167.tgz#81782880826222a7d66316db10c07cf149e5c034"
+  integrity sha512-ZCCjQro21kHlg/U8Er5zsKwEZeDOxmNEx5BcLxAuAr9JfJdrRjTRs++GFsvlKEW1lqWdn4AUEEO3LIWab2d7hw==
   dependencies:
     "@ethersproject/bytes" "^5.8.0"
     "@initia/initia.js" "1.0.4"
     "@iota/iota-sdk" "^1.6.1"
-    "@layerzerolabs/lz-definitions" "^3.0.152"
+    "@layerzerolabs/lz-definitions" "^3.0.167"
     "@mysten/sui" "^1.33.0"
     "@solana/web3.js" "1.95.8"
     "@ton/core" "^0.59.0"
@@ -1178,10 +1193,10 @@
     picocolors "1.0.0"
     pino "^8.16.2"
 
-"@layerzerolabs/lz-v2-utilities@^3.0.123":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-v2-utilities/-/lz-v2-utilities-3.0.152.tgz#07c940f2013bd4cd351b65b091ab7cd1b87a6598"
-  integrity sha512-r96jPIwbapBLmpBh+ept0tq/ujMaR/f0WC+0CFOWg7uFd5lVN9yWfya7RPNwkw0e/oDb9EFBBy+7Pq1mUKCtXA==
+"@layerzerolabs/lz-v2-utilities@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/lz-v2-utilities/-/lz-v2-utilities-3.0.167.tgz#5a231bd61de57c62e2895b7574574679798a3d87"
+  integrity sha512-cEf3+rqz/2gUJo/yAykfIx+jE89p5furG4b4V9dOygjW+/A2VUDAHgKJ1px7xU783r4MPh7ng5D3UoIPnPJDUw==
   dependencies:
     "@ethersproject/abi" "^5.8.0"
     "@ethersproject/address" "^5.8.0"
@@ -1192,12 +1207,12 @@
     bs58 "^5.0.0"
     tiny-invariant "^1.3.1"
 
-"@layerzerolabs/tron-utilities@^3.0.152":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@layerzerolabs/tron-utilities/-/tron-utilities-3.0.152.tgz#ab01f6aeaf76e514799699ab8faa11e5a58ec7b9"
-  integrity sha512-LHgwg4lOOq9RJw9IYalclOsh0s1JFhR1Gzx/OMsHR4hPWX9YSV7MzuMdF0CA1GXhtlFOM/n4u5LZOQoHVB4Xnw==
+"@layerzerolabs/tron-utilities@^3.0.167":
+  version "3.0.167"
+  resolved "https://registry.yarnpkg.com/@layerzerolabs/tron-utilities/-/tron-utilities-3.0.167.tgz#06158e7473f4f54b4183cbf1b4fa7f43e75e5745"
+  integrity sha512-xwWT46sDczT499wTtzW8mLfIknR7eerUvv+wxRlwHnp3iu4hmHVKe+kxbCG673Uy8KuRkt1KeX14tFiyID6KfQ==
   dependencies:
-    "@layerzerolabs/lz-utilities" "^3.0.152"
+    "@layerzerolabs/lz-utilities" "^3.0.167"
     ethers "^5.8.0"
     tronweb "^5.3.1"
 
@@ -2179,25 +2194,26 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@^2.62.1:
-  version "2.234.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.234.1.tgz#d4cb658edf3d1027b69b1a13d2fe0abdcefd700d"
-  integrity sha512-2oNqAA1qjF9xHCom6yHuY8KE6UltK7pTg3egf/t1+C6/OFEaw9+jyhCWmTasGmvjyQSkbvKiCPZco0l+XVyxiQ==
+aws-cdk-lib@^2.249.0:
+  version "2.250.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.250.0.tgz#5487f502eafc886697f97586a6213a05e7ec3973"
+  integrity sha512-8U8/S9VcmKSc3MHZWiB7P0IecgXoohI8Ya3dgtZMgbzC4mB+MEQmsYBeNgm4vzGQdRos8HjQLnFX1IBlZh7jQA==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "2.2.258"
-    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^48.20.0"
+    "@aws-cdk/asset-awscli-v1" "2.2.273"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.1"
+    "@aws-cdk/cloud-assembly-api" "^2.2.0"
+    "@aws-cdk/cloud-assembly-schema" "^53.0.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^11.3.3"
     ignore "^5.3.2"
     jsonschema "^1.5.0"
     mime-types "^2.1.35"
-    minimatch "^3.1.2"
+    minimatch "^10.2.3"
     punycode "^2.3.1"
-    semver "^7.7.3"
+    semver "^7.7.4"
     table "^6.9.0"
-    yaml "1.10.2"
+    yaml "1.10.3"
 
 axios@^1.3.1, axios@^1.6.7, axios@^1.7.7, axios@^1.8.4:
   version "1.13.2"
@@ -2212,6 +2228,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base-x@^3.0.2:
   version "3.0.11"
@@ -2316,20 +2337,19 @@ borsh@^0.7.0:
     bs58 "^4.0.0"
     text-encoding-utf-8 "^1.0.2"
 
-brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
 brace-expansion@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  dependencies:
+    balanced-match "^4.0.2"
 
 brorand@^1.1.0:
   version "1.1.0"
@@ -2574,11 +2594,6 @@ commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 constructs@^10.0.0:
   version "10.4.4"
@@ -3980,12 +3995,12 @@ minimatch@^10.1.1:
   dependencies:
     "@isaacs/brace-expansion" "^5.0.0"
 
-minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^10.2.3:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^5.0.5"
 
 minimatch@^5.0.1:
   version "5.1.6"
@@ -4507,10 +4522,15 @@ semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@^7.1.2, semver@^7.3.5, semver@^7.6.3, semver@^7.7.2, semver@^7.7.3:
+semver@^7.1.2, semver@^7.3.5, semver@^7.6.3, semver@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+
+semver@^7.7.4:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -5048,10 +5068,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
## Description

Patches remaining minimatch vulnerabilities via production dependency bumps:

- **aws-cdk-lib** `^2.62.1→^2.249.0`: resolves `minimatch@3.x` (CVE-2026-27904, CVE-2026-26996, CVE-2026-27903) — aws-cdk-lib now requires `minimatch@^10.2.3`
- **@layerzerolabs/lz-solana-sdk-v2** `3.0.123→3.0.167`: aligns with gasolina-aws

Note: `minimatch@5.1.6` and `minimatch@10.1.1` from the `ethers-gcp-kms-signer → @google-cloud/kms → google-gax → protobufjs-cli` chain remain. These cannot be safely scoped using yarn v1 resolutions — deferred pending a fix upstream in `ethers-gcp-kms-signer` or migration to pnpm.

## Type of Change

- [x] 🧹 Chore (dependency updates, build changes, tooling, etc.)

## Plan

N/A — production dependency version bumps.

## Impact/Screenshots

`aws-cdk-lib` bumps from `^2.62.1` to `^2.249.0` — a significant version jump. The CDK API surface used in this repo should be verified post-merge. `lz-solana-sdk-v2` bump aligns with gasolina-aws which is already running `3.0.167`.

## Checklist

- [x] I have ensured that this PR is not too large. I understand that large PRs will be declined. I have created small/chunked and a scoped PR.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas and added/improved docs.

## Additional Notes

- This PR should be merged only after #24 is merged and validated.
- The `aws-cdk-lib` bump is the highest-risk change in this series — runtime testing of GCP-dependent services is recommended before merging.