### PR TITLE
fix: bump axios to ^1.15.0 to resolve CVE-2026-25639, CVE-2025-62718, CVE-2026-40175

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
         "node-forge": "^1.4.0",
         "lodash": "^4.18.0",
         "underscore": "^1.13.8",
-        "@isaacs/brace-expansion": "^5.0.1"
+        "@isaacs/brace-expansion": "^5.0.1",
+        "axios": "^1.15.0"
     },
     "dependencies": {
         "@layerzerolabs/lz-definitions": "^3.0.123",
         "@layerzerolabs/lz-solana-sdk-v2": "3.0.167",
         "args": "^5.0.3",
         "aws-cdk-lib": "^2.249.0",
-        "axios": "^1.3.1",
+        "axios": "^1.15.0",
         "bs58": "^5.0.0",
         "command-line-args": "^5.2.1",
         "constructs": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,14 +2215,14 @@ aws-cdk-lib@^2.249.0:
     table "^6.9.0"
     yaml "1.10.3"
 
-axios@^1.3.1, axios@^1.6.7, axios@^1.7.7, axios@^1.8.4:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.2.tgz#9ada120b7b5ab24509553ec3e40123521117f687"
-  integrity sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==
+axios@^1.15.0, axios@^1.6.7, axios@^1.7.7, axios@^1.8.4:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -3243,10 +3243,10 @@ find-replace@^3.0.0:
   dependencies:
     array-back "^3.0.1"
 
-follow-redirects@^1.15.6:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.15.11:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -3255,7 +3255,7 @@ for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-form-data@^4.0.4:
+form-data@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -4320,10 +4320,10 @@ protobufjs@7.2.4, protobufjs@^7.0.0, protobufjs@^7.2.5, protobufjs@^7.3.2:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode.js@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
## Description

Bumps `axios` from `^1.3.1` to `^1.15.0` and adds a blanket yarn resolution to resolve three CVEs:

- CVE-2026-25639
- CVE-2025-62718
- CVE-2026-40175

The yarn resolution was required in addition to the direct dep bump because `@ton/ton` (via `lz-utilities`) pins `axios@1.13.2` as a nested dependency.

Fix version `1.15.0` was released April 8, 2026.

## Type of Change

- [x] 🧹 Chore (dependency updates, build changes, tooling, etc.)

## Plan

N/A — direct dependency bump and yarn resolution.

## Impact/Screenshots

No functional changes.

## Checklist

- [x] I have ensured that this PR is not too large. I understand that large PRs will be declined. I have created small/chunked and a scoped PR.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas and added/improved docs.

## Additional Notes

This PR should be merged after #23, #24, and #25.